### PR TITLE
Normalize PDF text cleaning and add tests

### DIFF
--- a/convex/__tests__/cleanPDFText.test.ts
+++ b/convex/__tests__/cleanPDFText.test.ts
@@ -1,0 +1,61 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+import { cleanPDFText } from "../knowledgeActions";
+
+describe("cleanPDFText", () => {
+  it("mantiene la struttura dei paragrafi dopo la normalizzazione", () => {
+    const rawText = [
+      "INTRODUZIONE",
+      "",
+      "Sezione 1: Panoramica",
+      "Questo    è    il    primo    paragrafo   con    spazi extra.",
+      "Prosegue sulla riga successiva con   altri   spazi.",
+      "",
+      "",
+      "Sezione 2: Dettagli",
+      "Un altro paragrafo con testo rilevante.",
+      "",
+      "",
+      "",
+      "Conclusioni",
+    ].join("\r\n");
+
+    const cleaned = cleanPDFText(rawText);
+
+    const expected = [
+      "INTRODUZIONE",
+      "",
+      "Sezione 1: Panoramica",
+      "Questo è il primo paragrafo con spazi extra.",
+      "Prosegue sulla riga successiva con altri spazi.",
+      "",
+      "Sezione 2: Dettagli",
+      "Un altro paragrafo con testo rilevante.",
+      "",
+      "Conclusioni",
+    ].join("\n");
+
+    assert.equal(cleaned, expected);
+  });
+
+  it("normalizza whitespace e newline senza perdere righe singole", () => {
+    const rawText = "Prima riga\r\nSeconda    riga\r\n\r\n\r\nTerza riga con\tspazi\r\n  \r\nQuarta riga";
+
+    const cleaned = cleanPDFText(rawText);
+
+    assert.equal(
+      cleaned,
+      [
+        "Prima riga",
+        "Seconda riga",
+        "",
+        "Terza riga con spazi",
+        "",
+        "Quarta riga",
+      ].join("\n"),
+    );
+    assert.equal(/\r/.test(cleaned), false);
+    assert.equal(/\n{3,}/.test(cleaned), false);
+  });
+});

--- a/convex/knowledgeActions.ts
+++ b/convex/knowledgeActions.ts
@@ -471,18 +471,25 @@ export const processPDFDocument = action({
 });
 
 // Funzione helper per pulire il testo estratto dai PDF
-function cleanPDFText(text: string): string {
-  return text
+export function cleanPDFText(text: string): string {
+  let cleaned = text
+    // Normalizza le sequenze di newline di Windows/Mac in newline Unix
+    .replace(/\r\n?/g, '\n')
     // Rimuovi caratteri di controllo e caratteri speciali problematici
     .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
-    // Normalizza gli spazi bianchi
-    .replace(/\s+/g, ' ')
-    // Rimuovi spazi multipli
-    .replace(/[ ]{2,}/g, ' ')
+    // Comprimi gli spazi consecutivi senza toccare i newline
+    .replace(/[^\S\n]+/g, ' ')
     // Ripara le parole spezzate a fine riga
-    .replace(/(\w)-\s+(\w)/g, '$1$2')
-    // Normalizza le interruzioni di riga
-    .replace(/\n\s*\n/g, '\n\n')
-    // Rimuovi spazi all'inizio e alla fine
+    .replace(/(\w)-\s+(\w)/g, '$1$2');
+
+  cleaned = cleaned
+    // Rimuovi spazi all'inizio o fine riga
+    .replace(/[^\S\n]+\n/g, '\n')
+    .replace(/\n[^\S\n]+/g, '\n')
+    // Limita le righe vuote consecutive a un massimo di due newline
+    .replace(/\n{3,}/g, '\n\n')
+    // Rimuovi spazi all'inizio e alla fine del documento
     .trim();
+
+  return cleaned;
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "predev": "convex dev --until-success && convex dev --once --run-sh \"node setup.mjs --once\" && convex dashboard",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "npm run test:build && node --test dist-tests/__tests__/cleanPDFText.test.js",
+    "test:build": "tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.31",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./convex/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist-tests",
+    "module": "CommonJS",
+    "target": "ES2019",
+    "moduleResolution": "Node",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "convex/**/*.ts",
+    "convex/_generated/**/*.js"
+  ],
+  "exclude": [
+    "convex/_generated/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- normalize `cleanPDFText` to collapse control characters, unify CRLF, and constrain blank-line expansion while preserving single newlines
- add node:test-based coverage ensuring paragraph structures survive the cleaning pass
- add a dedicated test TypeScript config and npm scripts to build and execute the new tests
- manually verified that chunking a multi-section PDF sample keeps section headers and paragraphs separated after cleaning

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb2ce52f1883329c7032dcd5d7ef85